### PR TITLE
chore: Migrate from kotlin-formatter to spotless

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,6 @@ bin/** linguist-generated=true
 
 # Gradle wrapper and related binaries
 gradle/wrapper/** linguist-generated=true
+
+# JOOQ generated sources
+src/generated/jooq/** linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ web/node_modules/
 
 # Kotlin Formatter
 .kotlinformatter/
+/.hermit/node/cache/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.wire)
     alias(libs.plugins.flyway)
     alias(libs.plugins.jooq)
-    alias(libs.plugins.kotlin.formatter)
+    alias(libs.plugins.spotless)
     application
 }
 
@@ -110,8 +110,19 @@ tasks.test {
     useJUnitPlatform()
 }
 
-tasks.named("check") {
-    dependsOn("checkFormatting")
+spotless {
+  kotlin {
+    target("src/main/kotlin/**/*.kt", "src/test/kotlin/**/*.kt")
+    ktlint().editorConfigOverride(
+      mapOf(
+        "ktlint_standard_class-signature" to "disabled",
+        "ktlint_standard_function-expression-body" to "disabled",
+      ),
+    )
+  }
+  kotlinGradle {
+    ktlint()
+  }
 }
 
 val npmCommand = file("bin/npm").absolutePath

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ wire = "5.4.0"
 flyway = "11.1.0"
 jooq = "3.19.16"
 mysql-connector = "9.1.0"
-kotlin-formatter = "1.6.3"
+spotless = "8.1.0"
 
 [libraries]
 misk-bom = { module = "com.squareup.misk:misk-bom", version.ref = "misk" }
@@ -29,4 +29,4 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 wire = { id = "com.squareup.wire", version.ref = "wire" }
 flyway = { id = "net.ltgt.flyway", version = "0.2.0" }
 jooq = { id = "org.jooq.jooq-codegen-gradle", version.ref = "jooq" }
-kotlin-formatter = { id = "xyz.block.kotlin-formatter", version.ref = "kotlin-formatter" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,5 +3,6 @@ pre-commit:
   commands:
     format:
       glob: "*.{kt,kts}"
+      exclude: "src/generated/**"
       run: bin/kotlin-format --set-exit-if-changed {staged_files}
       stage_fixed: true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,14 +1,14 @@
 rootProject.name = "builder-syndicate"
 
 pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenCentral()
-    }
+  repositories {
+    gradlePluginPortal()
+    mavenCentral()
+  }
 }
 
 dependencyResolutionManagement {
-    repositories {
-        mavenCentral()
-    }
+  repositories {
+    mavenCentral()
+  }
 }


### PR DESCRIPTION
This gives light styling without adding newline reversions.