### PR TITLE
feat(core): Add PostService with markdown rendering

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,8 @@ dependencies {
   implementation(libs.wire.runtime)
   implementation(libs.jooq.runtime)
   implementation(libs.mysql.connector)
+  implementation(libs.commonmark)
+  implementation(libs.owasp.html.sanitizer)
 
   flyway(libs.flyway.core)
   flyway(libs.flyway.mysql)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,8 @@ flyway = "11.1.0"
 jooq = "3.19.16"
 mysql-connector = "9.1.0"
 spotless = "8.1.0"
+commonmark = "0.24.0"
+owasp-html-sanitizer = "20240325.1"
 
 [libraries]
 misk-bom = { module = "com.squareup.misk:misk-bom", version.ref = "misk" }
@@ -23,6 +25,8 @@ flyway-core = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
 flyway-mysql = { module = "org.flywaydb:flyway-mysql", version.ref = "flyway" }
 mysql-connector = { module = "com.mysql:mysql-connector-j", version.ref = "mysql-connector" }
 jooq-runtime = { module = "org.jooq:jooq", version.ref = "jooq" }
+commonmark = { module = "org.commonmark:commonmark", version.ref = "commonmark" }
+owasp-html-sanitizer = { module = "com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer", version.ref = "owasp-html-sanitizer" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/src/generated/jooq/xyz/block/buildersyndicate/adapters/db/jooq/tables/Posts.kt
+++ b/src/generated/jooq/xyz/block/buildersyndicate/adapters/db/jooq/tables/Posts.kt
@@ -100,6 +100,11 @@ open class Posts(
     val BODY: TableField<PostsRecord, String?> = createField(DSL.name("body"), SQLDataType.CLOB.nullable(false), this, "")
 
     /**
+     * The column <code>buildersyndicate.posts.body_html</code>.
+     */
+    val BODY_HTML: TableField<PostsRecord, String?> = createField(DSL.name("body_html"), SQLDataType.CLOB.nullable(false), this, "")
+
+    /**
      * The column <code>buildersyndicate.posts.created_at</code>.
      */
     val CREATED_AT: TableField<PostsRecord, LocalDateTime?> = createField(DSL.name("created_at"), SQLDataType.LOCALDATETIME(0).nullable(false).defaultValue(DSL.field(DSL.raw("CURRENT_TIMESTAMP"), SQLDataType.LOCALDATETIME)), this, "")

--- a/src/generated/jooq/xyz/block/buildersyndicate/adapters/db/jooq/tables/pojos/Posts.kt
+++ b/src/generated/jooq/xyz/block/buildersyndicate/adapters/db/jooq/tables/pojos/Posts.kt
@@ -17,6 +17,7 @@ data class Posts(
     val authorId: Long? = null,
     val title: String? = null,
     val body: String? = null,
+    val bodyHtml: String? = null,
     val createdAt: LocalDateTime? = null,
     val updatedAt: LocalDateTime? = null
 ): Serializable {
@@ -53,6 +54,12 @@ data class Posts(
         }
         else if (this.body != o.body)
             return false
+        if (this.bodyHtml == null) {
+            if (o.bodyHtml != null)
+                return false
+        }
+        else if (this.bodyHtml != o.bodyHtml)
+            return false
         if (this.createdAt == null) {
             if (o.createdAt != null)
                 return false
@@ -75,6 +82,7 @@ data class Posts(
         result = prime * result + (if (this.authorId == null) 0 else this.authorId.hashCode())
         result = prime * result + (if (this.title == null) 0 else this.title.hashCode())
         result = prime * result + (if (this.body == null) 0 else this.body.hashCode())
+        result = prime * result + (if (this.bodyHtml == null) 0 else this.bodyHtml.hashCode())
         result = prime * result + (if (this.createdAt == null) 0 else this.createdAt.hashCode())
         result = prime * result + (if (this.updatedAt == null) 0 else this.updatedAt.hashCode())
         return result
@@ -87,6 +95,7 @@ data class Posts(
         sb.append(", ").append(authorId)
         sb.append(", ").append(title)
         sb.append(", ").append(body)
+        sb.append(", ").append(bodyHtml)
         sb.append(", ").append(createdAt)
         sb.append(", ").append(updatedAt)
 

--- a/src/generated/jooq/xyz/block/buildersyndicate/adapters/db/jooq/tables/records/PostsRecord.kt
+++ b/src/generated/jooq/xyz/block/buildersyndicate/adapters/db/jooq/tables/records/PostsRecord.kt
@@ -34,13 +34,17 @@ open class PostsRecord() : UpdatableRecordImpl<PostsRecord>(Posts.POSTS) {
         set(value): Unit = set(3, value)
         get(): String? = get(3) as String?
 
-    open var createdAt: LocalDateTime?
+    open var bodyHtml: String?
         set(value): Unit = set(4, value)
-        get(): LocalDateTime? = get(4) as LocalDateTime?
+        get(): String? = get(4) as String?
 
-    open var updatedAt: LocalDateTime?
+    open var createdAt: LocalDateTime?
         set(value): Unit = set(5, value)
         get(): LocalDateTime? = get(5) as LocalDateTime?
+
+    open var updatedAt: LocalDateTime?
+        set(value): Unit = set(6, value)
+        get(): LocalDateTime? = get(6) as LocalDateTime?
 
     // -------------------------------------------------------------------------
     // Primary key information
@@ -51,11 +55,12 @@ open class PostsRecord() : UpdatableRecordImpl<PostsRecord>(Posts.POSTS) {
     /**
      * Create a detached, initialised PostsRecord
      */
-    constructor(id: Long? = null, authorId: Long? = null, title: String? = null, body: String? = null, createdAt: LocalDateTime? = null, updatedAt: LocalDateTime? = null): this() {
+    constructor(id: Long? = null, authorId: Long? = null, title: String? = null, body: String? = null, bodyHtml: String? = null, createdAt: LocalDateTime? = null, updatedAt: LocalDateTime? = null): this() {
         this.id = id
         this.authorId = authorId
         this.title = title
         this.body = body
+        this.bodyHtml = bodyHtml
         this.createdAt = createdAt
         this.updatedAt = updatedAt
         resetChangedOnNotNull()
@@ -70,6 +75,7 @@ open class PostsRecord() : UpdatableRecordImpl<PostsRecord>(Posts.POSTS) {
             this.authorId = value.authorId
             this.title = value.title
             this.body = value.body
+            this.bodyHtml = value.bodyHtml
             this.createdAt = value.createdAt
             this.updatedAt = value.updatedAt
             resetChangedOnNotNull()

--- a/src/main/kotlin/xyz/block/buildersyndicate/adapters/db/JooqPostRepository.kt
+++ b/src/main/kotlin/xyz/block/buildersyndicate/adapters/db/JooqPostRepository.kt
@@ -26,6 +26,7 @@ public class JooqPostRepository @Inject constructor(
       authorId = post.authorId
       title = post.title
       body = post.body
+      bodyHtml = post.bodyHtml
     }
     record.store()
     record.refresh()
@@ -41,6 +42,7 @@ public class JooqPostRepository @Inject constructor(
       authorId = post.authorId
       title = post.title
       body = post.body
+      bodyHtml = post.bodyHtml
     }
     record.store()
     return record.toPost()
@@ -73,6 +75,7 @@ public class JooqPostRepository @Inject constructor(
     authorId = this.authorId!!,
     title = this.title!!,
     body = this.body!!,
+    bodyHtml = this.bodyHtml ?: "",
     createdAt = this.createdAt?.atZone(ZoneId.of("UTC"))?.toInstant(),
     updatedAt = this.updatedAt?.atZone(ZoneId.of("UTC"))?.toInstant(),
   )

--- a/src/main/kotlin/xyz/block/buildersyndicate/adapters/markdown/SanitizingMarkdownRenderer.kt
+++ b/src/main/kotlin/xyz/block/buildersyndicate/adapters/markdown/SanitizingMarkdownRenderer.kt
@@ -1,0 +1,34 @@
+package xyz.block.buildersyndicate.adapters.markdown
+
+import org.commonmark.parser.Parser
+import org.commonmark.renderer.html.HtmlRenderer
+import org.owasp.html.HtmlPolicyBuilder
+import org.owasp.html.PolicyFactory
+import xyz.block.buildersyndicate.core.posts.MarkdownRenderer
+
+class SanitizingMarkdownRenderer : MarkdownRenderer {
+  private val parser: Parser = Parser.builder().build()
+  private val renderer: HtmlRenderer = HtmlRenderer.builder().build()
+
+  private val policy: PolicyFactory = HtmlPolicyBuilder()
+    .allowElements(
+      "p", "br", "hr",
+      "h1", "h2", "h3", "h4", "h5", "h6",
+      "ul", "ol", "li",
+      "blockquote", "pre", "code",
+      "strong", "em", "b", "i", "u", "s", "del",
+      "a", "img",
+      "table", "thead", "tbody", "tr", "th", "td",
+    )
+    .allowAttributes("href").onElements("a")
+    .allowAttributes("src", "alt", "title").onElements("img")
+    .allowUrlProtocols("http", "https", "mailto")
+    .requireRelNofollowOnLinks()
+    .toFactory()
+
+  override fun render(markdown: String): String {
+    val document = parser.parse(markdown)
+    val rawHtml = renderer.render(document)
+    return policy.sanitize(rawHtml)
+  }
+}

--- a/src/main/kotlin/xyz/block/buildersyndicate/core/posts/MarkdownRenderer.kt
+++ b/src/main/kotlin/xyz/block/buildersyndicate/core/posts/MarkdownRenderer.kt
@@ -1,0 +1,5 @@
+package xyz.block.buildersyndicate.core.posts
+
+interface MarkdownRenderer {
+  fun render(markdown: String): String
+}

--- a/src/main/kotlin/xyz/block/buildersyndicate/core/posts/Post.kt
+++ b/src/main/kotlin/xyz/block/buildersyndicate/core/posts/Post.kt
@@ -7,6 +7,7 @@ data class Post(
   val authorId: Long,
   val title: String,
   val body: String,
+  val bodyHtml: String,
   val createdAt: Instant? = null,
   val updatedAt: Instant? = null,
 )

--- a/src/main/kotlin/xyz/block/buildersyndicate/core/posts/PostService.kt
+++ b/src/main/kotlin/xyz/block/buildersyndicate/core/posts/PostService.kt
@@ -1,0 +1,49 @@
+package xyz.block.buildersyndicate.core.posts
+
+class PostService(
+  private val postRepository: PostRepository,
+  private val markdownRenderer: MarkdownRenderer,
+) {
+  fun create(authorId: Long, title: String, body: String): Post {
+    val bodyHtml = markdownRenderer.render(body)
+    val post = Post(
+      authorId = authorId,
+      title = title,
+      body = body,
+      bodyHtml = bodyHtml,
+    )
+    return postRepository.create(post)
+  }
+
+  fun update(postId: Long, requestingUserId: Long, title: String, body: String): Post {
+    val existing = postRepository.findById(postId)
+      ?: throw IllegalArgumentException("Post not found: $postId")
+
+    if (existing.authorId != requestingUserId) {
+      throw IllegalStateException("Only the author can update this post")
+    }
+
+    val bodyHtml = markdownRenderer.render(body)
+    val updated = existing.copy(
+      title = title,
+      body = body,
+      bodyHtml = bodyHtml,
+    )
+    return postRepository.update(updated)
+  }
+
+  fun delete(postId: Long, requestingUserId: Long) {
+    val existing = postRepository.findById(postId)
+      ?: throw IllegalArgumentException("Post not found: $postId")
+
+    if (existing.authorId != requestingUserId) {
+      throw IllegalStateException("Only the author can delete this post")
+    }
+
+    postRepository.delete(postId)
+  }
+
+  fun getById(id: Long): Post? = postRepository.findById(id)
+
+  fun listRecent(limit: Int = 20): List<Post> = postRepository.listRecent(limit)
+}

--- a/src/main/resources/db/migration/V004__add_body_html_column.sql
+++ b/src/main/resources/db/migration/V004__add_body_html_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE posts ADD COLUMN body_html TEXT NOT NULL AFTER body;

--- a/src/test/kotlin/xyz/block/buildersyndicate/adapters/db/JooqPostRepositoryTest.kt
+++ b/src/test/kotlin/xyz/block/buildersyndicate/adapters/db/JooqPostRepositoryTest.kt
@@ -57,6 +57,7 @@ class JooqPostRepositoryTest {
       authorId = testUser.id!!,
       title = "Test Post Title",
       body = "This is the body of the test post.",
+      bodyHtml = "<p>This is the body of the test post.</p>",
     )
 
     val created = postRepository.create(post)
@@ -79,6 +80,7 @@ class JooqPostRepositoryTest {
       authorId = testUser.id!!,
       title = "Original Title",
       body = "Original body",
+      bodyHtml = "<p>Original body</p>",
     )
 
     val created = postRepository.create(post)
@@ -86,6 +88,7 @@ class JooqPostRepositoryTest {
       created.copy(
         title = "Updated Title",
         body = "Updated body content",
+        bodyHtml = "<p>Updated body content</p>",
       ),
     )
 
@@ -101,6 +104,7 @@ class JooqPostRepositoryTest {
       authorId = testUser.id!!,
       title = "Post to Delete",
       body = "This post will be deleted",
+      bodyHtml = "<p>This post will be deleted</p>",
     )
 
     val created = postRepository.create(post)
@@ -117,6 +121,7 @@ class JooqPostRepositoryTest {
         authorId = testUser.id!!,
         title = "First Post",
         body = "Created first",
+        bodyHtml = "<p>Created first</p>",
       ),
     )
     Thread.sleep(1100)
@@ -125,6 +130,7 @@ class JooqPostRepositoryTest {
         authorId = testUser.id!!,
         title = "Second Post",
         body = "Created second",
+        bodyHtml = "<p>Created second</p>",
       ),
     )
     Thread.sleep(1100)
@@ -133,6 +139,7 @@ class JooqPostRepositoryTest {
         authorId = testUser.id!!,
         title = "Third Post",
         body = "Created third",
+        bodyHtml = "<p>Created third</p>",
       ),
     )
 
@@ -150,6 +157,7 @@ class JooqPostRepositoryTest {
       authorId = 999999L,
       title = "Invalid Post",
       body = "This should fail",
+      bodyHtml = "<p>This should fail</p>",
     )
 
     assertThrows<Exception> {
@@ -178,6 +186,7 @@ class JooqPostRepositoryTest {
         authorId = testUser.id!!,
         title = "Test User Post",
         body = "By test user",
+        bodyHtml = "<p>By test user</p>",
       ),
     )
     postRepository.create(
@@ -185,6 +194,7 @@ class JooqPostRepositoryTest {
         authorId = otherUser.id!!,
         title = "Other User Post",
         body = "By other user",
+        bodyHtml = "<p>By other user</p>",
       ),
     )
 

--- a/src/test/kotlin/xyz/block/buildersyndicate/adapters/markdown/SanitizingMarkdownRendererTest.kt
+++ b/src/test/kotlin/xyz/block/buildersyndicate/adapters/markdown/SanitizingMarkdownRendererTest.kt
@@ -1,0 +1,74 @@
+package xyz.block.buildersyndicate.adapters.markdown
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SanitizingMarkdownRendererTest {
+
+  private val renderer = SanitizingMarkdownRenderer()
+
+  @Test
+  fun `renders markdown to HTML`() {
+    val html = renderer.render("Hello **world**")
+
+    assertEquals("<p>Hello <strong>world</strong></p>\n", html)
+  }
+
+  @Test
+  fun `strips script tags from output`() {
+    val html = renderer.render("Hello <script>alert('xss')</script> world")
+
+    assertFalse(html.contains("<script>"))
+    assertFalse(html.contains("alert"))
+    assertTrue(html.contains("Hello"))
+    assertTrue(html.contains("world"))
+  }
+
+  @Test
+  fun `strips inline script handlers`() {
+    val html = renderer.render("<img src=\"x\" onerror=\"alert('xss')\">")
+
+    assertFalse(html.contains("onerror"))
+    assertFalse(html.contains("alert"))
+  }
+
+  @Test
+  fun `allows safe markdown elements`() {
+    val markdown = """
+            # Header
+            
+            - Item 1
+            - Item 2
+            
+            **bold** and *italic*
+            
+            [link](https://example.com)
+    """.trimIndent()
+
+    val html = renderer.render(markdown)
+
+    assertTrue(html.contains("<h1>"))
+    assertTrue(html.contains("<li>"))
+    assertTrue(html.contains("<strong>"))
+    assertTrue(html.contains("<em>"))
+    assertTrue(html.contains("<a "))
+    assertTrue(html.contains("href=\"https://example.com\""))
+  }
+
+  @Test
+  fun `strips javascript URLs`() {
+    val html = renderer.render("[click me](javascript:alert('xss'))")
+
+    assertFalse(html.contains("javascript:"))
+    assertFalse(html.contains("alert"))
+  }
+
+  @Test
+  fun `adds nofollow to links`() {
+    val html = renderer.render("[link](https://example.com)")
+
+    assertTrue(html.contains("rel=\"nofollow\""))
+  }
+}

--- a/src/test/kotlin/xyz/block/buildersyndicate/core/posts/PostServiceTest.kt
+++ b/src/test/kotlin/xyz/block/buildersyndicate/core/posts/PostServiceTest.kt
@@ -1,0 +1,111 @@
+package xyz.block.buildersyndicate.core.posts
+
+import java.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+
+class PostServiceTest {
+
+  private class FakeMarkdownRenderer : MarkdownRenderer {
+    override fun render(markdown: String): String = "<p>$markdown</p>"
+  }
+
+  private class FakePostRepository : PostRepository {
+    private val posts = mutableMapOf<Long, Post>()
+    private var nextId = 1L
+
+    override fun findById(id: Long): Post? = posts[id]
+
+    override fun create(post: Post): Post {
+      val id = nextId++
+      val now = Instant.now()
+      val created = post.copy(id = id, createdAt = now, updatedAt = now)
+      posts[id] = created
+      return created
+    }
+
+    override fun update(post: Post): Post {
+      val id = post.id ?: throw IllegalArgumentException("Post must have an id")
+      val updated = post.copy(updatedAt = Instant.now())
+      posts[id] = updated
+      return updated
+    }
+
+    override fun delete(id: Long): Boolean {
+      return posts.remove(id) != null
+    }
+
+    override fun listByAuthor(authorId: Long): List<Post> = posts.values.filter { it.authorId == authorId }
+
+    override fun listRecent(limit: Int): List<Post> = posts.values.sortedByDescending { it.createdAt }.take(limit)
+  }
+
+  @Test
+  fun `create post with markdown body produces HTML`() {
+    val service = PostService(FakePostRepository(), FakeMarkdownRenderer())
+
+    val post = service.create(authorId = 1L, title = "Test", body = "Hello **world**")
+
+    assertNotNull(post.id)
+    assertEquals("Hello **world**", post.body)
+    assertEquals("<p>Hello **world**</p>", post.bodyHtml)
+  }
+
+  @Test
+  fun `update post re-renders markdown to HTML`() {
+    val service = PostService(FakePostRepository(), FakeMarkdownRenderer())
+    val created = service.create(authorId = 1L, title = "Test", body = "Original")
+
+    val updated = service.update(
+      postId = created.id!!,
+      requestingUserId = 1L,
+      title = "Updated Title",
+      body = "Updated body",
+    )
+
+    assertEquals("Updated body", updated.body)
+    assertEquals("<p>Updated body</p>", updated.bodyHtml)
+  }
+
+  @Test
+  fun `only post author can update their post`() {
+    val service = PostService(FakePostRepository(), FakeMarkdownRenderer())
+    val created = service.create(authorId = 1L, title = "Test", body = "Content")
+
+    val exception = assertFailsWith<IllegalStateException> {
+      service.update(
+        postId = created.id!!,
+        requestingUserId = 999L,
+        title = "Hacked",
+        body = "Hacked content",
+      )
+    }
+
+    assertEquals("Only the author can update this post", exception.message)
+  }
+
+  @Test
+  fun `only post author can delete their post`() {
+    val service = PostService(FakePostRepository(), FakeMarkdownRenderer())
+    val created = service.create(authorId = 1L, title = "Test", body = "Content")
+
+    val exception = assertFailsWith<IllegalStateException> {
+      service.delete(postId = created.id!!, requestingUserId = 999L)
+    }
+
+    assertEquals("Only the author can delete this post", exception.message)
+  }
+
+  @Test
+  fun `author can delete their own post`() {
+    val repository = FakePostRepository()
+    val service = PostService(repository, FakeMarkdownRenderer())
+    val created = service.create(authorId = 1L, title = "Test", body = "Content")
+
+    service.delete(postId = created.id!!, requestingUserId = 1L)
+
+    assertEquals(null, service.getById(created.id!!))
+  }
+}


### PR DESCRIPTION
# feat(core): Add PostService with markdown rendering

**Branch:** `MP2-post-service`
**Base:** `main`

## Summary
Business logic layer with CRUD, author validation, and markdown-to-HTML rendering using CommonMark + OWASP sanitizer.

<details><summary>Key files to review first</summary>

- `core/posts/PostService.kt` — business logic, author validation
- `adapters/markdown/SanitizingMarkdownRenderer.kt` — CommonMark + OWASP

</details>

<details><summary>DB migrations</summary>

- `V004__add_body_html_column.sql` — adds `body_html` column to posts
- Rollback: `ALTER TABLE posts DROP COLUMN body_html`

</details>

## Feel it.
```bash
just test  # PostServiceTest + SanitizingMarkdownRendererTest pass
```

## Caveats / Follow-ups
- No rate limiting or content length limits
- CommonMark extensions (tables) not enabled

---

ref: #12
Closes: #12
