### PR TITLE
feat(ui): add React Router, dark/light theme, and design tokens

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.1",
       "dependencies": {
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^7.13.0"
       },
       "devDependencies": {
         "@types/react": "^18.3.12",
@@ -50,7 +51,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1174,7 +1174,6 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1240,7 +1239,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1282,6 +1280,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://global.block-artifacts.com/artifactory/api/npm/square-npm/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -1510,7 +1521,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1552,7 +1562,6 @@
       "resolved": "https://global.block-artifacts.com/artifactory/api/npm/square-npm/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -1581,6 +1590,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.13.0",
+      "resolved": "https://global.block-artifacts.com/artifactory/api/npm/square-npm/react-router/-/react-router-7.13.0.tgz",
+      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.0",
+      "resolved": "https://global.block-artifacts.com/artifactory/api/npm/square-npm/react-router-dom/-/react-router-dom-7.13.0.tgz",
+      "integrity": "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/rollup": {
@@ -1642,6 +1689,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://global.block-artifacts.com/artifactory/api/npm/square-npm/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -1720,7 +1773,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^7.13.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2,52 +2,149 @@
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  background-color: var(--bg-deep);
 }
 
+/* Navigation - Glass-morphism */
 .nav {
-  background-color: #2c3e50;
-  color: white;
-  padding: 0.75rem 1.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background: var(--nav-bg);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  border-bottom: 1px solid var(--nav-border);
+  padding: var(--sp-3) var(--sp-6);
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
 
 .nav-brand {
-  font-size: 1.25rem;
-  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  font-size: var(--text-lg);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  background: var(--gradient-primary);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
-.nav-links {
+.nav-brand-icon {
+  width: 36px;
+  height: 36px;
+  background: var(--gradient-primary);
+  border-radius: var(--radius-md);
+  display: grid;
+  place-items: center;
+  box-shadow: var(--shadow-glow);
+  -webkit-text-fill-color: initial;
+}
+
+.nav-brand:hover {
+  opacity: 0.9;
+}
+
+.nav-actions {
   display: flex;
-  gap: 1rem;
+  align-items: center;
+  gap: var(--sp-3);
 }
 
 .nav-link {
-  color: #ecf0f1;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-  transition: background-color 0.2s;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  padding: var(--sp-1) var(--sp-2);
+  border-radius: var(--radius-sm);
+  transition: color var(--transition-fast), background-color var(--transition-fast);
 }
 
 .nav-link:hover {
-  background-color: rgba(255, 255, 255, 0.1);
-  text-decoration: none;
+  color: var(--text-primary);
+  background-color: var(--bg-hover);
 }
 
+.nav-user {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 500;
+}
+
+.nav-btn {
+  background: none;
+  border: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  padding: var(--sp-1) var(--sp-3);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: color var(--transition-fast), border-color var(--transition-fast), background-color var(--transition-fast);
+}
+
+.nav-btn:hover {
+  color: var(--text-primary);
+  border-color: var(--border-accent);
+  background-color: var(--bg-hover);
+}
+
+.theme-toggle {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  transition: background-color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.theme-toggle:hover {
+  background-color: var(--bg-hover);
+  border-color: var(--border-accent);
+}
+
+/* Main content */
 .main {
   flex: 1;
-  padding: 2rem;
-  max-width: 1200px;
+  padding: var(--sp-8) var(--sp-6);
+  max-width: 800px;
   margin: 0 auto;
   width: 100%;
 }
 
-.main h1 {
-  margin-bottom: 1rem;
-  color: #2c3e50;
+.placeholder {
+  text-align: center;
+  padding: var(--sp-16) 0;
 }
 
-.main p {
-  color: #7f8c8d;
+.placeholder h1 {
+  font-size: var(--text-3xl);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  color: var(--text-primary);
+  margin-bottom: var(--sp-2);
+}
+
+.placeholder p {
+  color: var(--text-secondary);
+  font-size: var(--text-lg);
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .nav {
+    padding: var(--sp-3) var(--sp-4);
+  }
+
+  .main {
+    padding: var(--sp-4);
+  }
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,19 +1,45 @@
+import { BrowserRouter, Routes, Route, Link } from 'react-router-dom'
+import { ThemeProvider, useTheme } from './hooks/useTheme'
+import logo from './assets/logo.svg'
+import './styles/theme.css'
 import './App.css'
+
+function NavBar() {
+  const { theme, toggleTheme } = useTheme()
+
+  return (
+    <nav className="nav">
+      <Link to="/" className="nav-brand">
+        <div className="nav-brand-icon"><img src={logo} alt="BBS" width={24} height={24} /></div>
+        <span>Builder Syndicate</span>
+      </Link>
+      <div className="nav-actions">
+        <button
+          className="theme-toggle"
+          onClick={toggleTheme}
+          aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+        >
+          {theme === 'dark' ? '☀️' : '🌙'}
+        </button>
+      </div>
+    </nav>
+  )
+}
 
 function App() {
   return (
-    <div className="app">
-      <nav className="nav">
-        <div className="nav-brand">Builder Syndicate</div>
-        <div className="nav-links">
-          <a href="/" className="nav-link">Home</a>
+    <BrowserRouter basename="/app">
+      <ThemeProvider>
+        <div className="app">
+          <NavBar />
+          <main className="main">
+            <Routes>
+              <Route path="/" element={<div className="placeholder"><h1>Builder Syndicate</h1><p>A link aggregator for builders.</p></div>} />
+            </Routes>
+          </main>
         </div>
-      </nav>
-      <main className="main">
-        <h1>Welcome to Builder Syndicate</h1>
-        <p>A link aggregator for builders.</p>
-      </main>
-    </div>
+      </ThemeProvider>
+    </BrowserRouter>
   )
 }
 

--- a/web/src/assets/logo.svg
+++ b/web/src/assets/logo.svg
@@ -1,0 +1,81 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <defs>
+    <linearGradient id="termGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0f1419"/>
+      <stop offset="100%" style="stop-color:#0a0e17"/>
+    </linearGradient>
+    <linearGradient id="textGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#6366f1"/>
+      <stop offset="50%" style="stop-color:#8b5cf6"/>
+      <stop offset="100%" style="stop-color:#d946ef"/>
+    </linearGradient>
+  </defs>
+  
+  <!-- CRT-style rounded screen background -->
+  <rect x="2" y="2" width="60" height="60" rx="10" fill="url(#termGrad)" stroke="#232d3b" stroke-width="1.5"/>
+  
+  <!-- Scanline effect hints -->
+  <line x1="4" y1="14" x2="60" y2="14" stroke="#8b5cf6" stroke-width="0.3" opacity="0.1"/>
+  <line x1="4" y1="26" x2="60" y2="26" stroke="#8b5cf6" stroke-width="0.3" opacity="0.1"/>
+  <line x1="4" y1="38" x2="60" y2="38" stroke="#8b5cf6" stroke-width="0.3" opacity="0.1"/>
+  <line x1="4" y1="50" x2="60" y2="50" stroke="#8b5cf6" stroke-width="0.3" opacity="0.1"/>
+  
+  <!-- Pixelated "BBS" in brand gradient - 3x5 pixel font style -->
+  <!-- B -->
+  <rect x="8" y="22" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="8" y="25" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="8" y="28" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="8" y="31" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="8" y="34" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="11" y="22" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="11" y="28" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="11" y="34" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="14" y="25" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="14" y="31" width="3" height="3" fill="url(#textGrad)"/>
+  
+  <!-- B -->
+  <rect x="20" y="22" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="20" y="25" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="20" y="28" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="20" y="31" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="20" y="34" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="23" y="22" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="23" y="28" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="23" y="34" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="26" y="25" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="26" y="31" width="3" height="3" fill="url(#textGrad)"/>
+  
+  <!-- S -->
+  <rect x="32" y="22" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="35" y="22" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="38" y="22" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="32" y="25" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="32" y="28" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="35" y="28" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="38" y="28" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="38" y="31" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="32" y="34" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="35" y="34" width="3" height="3" fill="url(#textGrad)"/>
+  <rect x="38" y="34" width="3" height="3" fill="url(#textGrad)"/>
+  
+  <!-- Blinking cursor -->
+  <rect x="44" y="34" width="3" height="3" fill="#d946ef" opacity="0.9"/>
+  
+  <!-- Connection status dots - 3x3 dial-up modem grid -->
+  <rect x="46" y="7" width="3" height="3" fill="#6366f1" opacity="0.3"/>
+  <rect x="50" y="7" width="3" height="3" fill="#6366f1" opacity="0.4"/>
+  <rect x="54" y="7" width="3" height="3" fill="#8b5cf6" opacity="0.5"/>
+  <rect x="46" y="11" width="3" height="3" fill="#6366f1" opacity="0.4"/>
+  <rect x="50" y="11" width="3" height="3" fill="#8b5cf6" opacity="0.6"/>
+  <rect x="54" y="11" width="3" height="3" fill="#8b5cf6" opacity="0.8"/>
+  <rect x="46" y="15" width="3" height="3" fill="#8b5cf6" opacity="0.6"/>
+  <rect x="50" y="15" width="3" height="3" fill="#d946ef" opacity="0.85"/>
+  <rect x="54" y="15" width="3" height="3" fill="#d946ef"/>
+  
+  <!-- Bottom prompt hint -->
+  <rect x="8" y="48" width="3" height="3" fill="#8b5cf6" opacity="0.4"/>
+  <rect x="12" y="48" width="12" height="3" fill="#6366f1" opacity="0.2"/>
+  
+  <!-- CRT glow effect -->
+  <rect x="4" y="4" width="56" height="56" rx="8" fill="none" stroke="#8b5cf6" stroke-width="0.5" opacity="0.15"/>
+</svg>

--- a/web/src/hooks/useTheme.tsx
+++ b/web/src/hooks/useTheme.tsx
@@ -1,0 +1,55 @@
+import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react'
+
+type Theme = 'dark' | 'light'
+
+interface ThemeContextValue {
+  theme: Theme
+  toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null)
+
+const STORAGE_KEY = 'theme'
+
+function getInitialTheme(): Theme {
+  const stored = localStorage.getItem(STORAGE_KEY)
+  if (stored === 'dark' || stored === 'light') return stored
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(getInitialTheme)
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme)
+  }, [theme])
+
+  useEffect(() => {
+    if (localStorage.getItem(STORAGE_KEY)) return
+
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    const handler = (e: MediaQueryListEvent) => setTheme(e.matches ? 'dark' : 'light')
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [])
+
+  const toggleTheme = useCallback(() => {
+    setTheme(prev => {
+      const next = prev === 'dark' ? 'light' : 'dark'
+      localStorage.setItem(STORAGE_KEY, next)
+      return next
+    })
+  }, [])
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider')
+  return ctx
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
+
 * {
   margin: 0;
   padding: 0;
@@ -5,17 +7,19 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+  font-family: var(--font-family);
+  font-size: var(--text-base);
   line-height: 1.6;
-  color: #333;
-  background-color: #f5f5f5;
+  color: var(--text-primary);
+  background-color: var(--bg-deep);
 }
 
 a {
-  color: inherit;
+  color: var(--primary-light);
   text-decoration: none;
+  transition: color var(--transition-fast);
 }
 
 a:hover {
-  text-decoration: underline;
+  color: var(--text-primary);
 }

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -1,0 +1,100 @@
+/* Midnight Forge (Dark) */
+[data-theme="dark"] {
+  --bg-deep: #0a0e17;
+  --bg-base: #0f1419;
+  --bg-elevated: #161d27;
+  --bg-card: #1a222d;
+  --bg-hover: #232d3b;
+
+  --text-primary: #f8fafc;
+  --text-secondary: #94a3b8;
+  --text-tertiary: #64748b;
+  --text-muted: #475569;
+
+  --primary: #8b5cf6;
+  --primary-light: #a78bfa;
+  --primary-glow: rgba(139, 92, 246, 0.15);
+
+  --border-subtle: rgba(255, 255, 255, 0.06);
+  --border-accent: rgba(139, 92, 246, 0.3);
+
+  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.4);
+  --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+  --shadow-glow: 0 0 30px rgba(139, 92, 246, 0.15);
+
+  --nav-bg: rgba(15, 20, 25, 0.85);
+  --nav-border: rgba(255, 255, 255, 0.06);
+
+  --error: #ef4444;
+  --error-bg: rgba(239, 68, 68, 0.1);
+}
+
+/* Daylight Forge (Light) */
+[data-theme="light"] {
+  --bg-deep: #f8fafc;
+  --bg-base: #ffffff;
+  --bg-elevated: #f1f5f9;
+  --bg-card: #ffffff;
+  --bg-hover: #f8fafc;
+
+  --text-primary: #0f172a;
+  --text-secondary: #475569;
+  --text-tertiary: #64748b;
+  --text-muted: #94a3b8;
+
+  --primary: #7c3aed;
+  --primary-light: #8b5cf6;
+  --primary-glow: rgba(124, 58, 237, 0.1);
+
+  --border-subtle: rgba(0, 0, 0, 0.08);
+  --border-accent: rgba(124, 58, 237, 0.25);
+
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08), 0 2px 4px rgba(0, 0, 0, 0.04);
+  --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.1), 0 4px 12px rgba(0, 0, 0, 0.05);
+  --shadow-glow: 0 0 30px rgba(124, 58, 237, 0.1);
+
+  --nav-bg: rgba(255, 255, 255, 0.9);
+  --nav-border: rgba(0, 0, 0, 0.06);
+
+  --error: #dc2626;
+  --error-bg: rgba(220, 38, 38, 0.08);
+}
+
+/* Shared tokens (both themes) */
+:root {
+  --gradient-primary: linear-gradient(135deg, #6366f1, #8b5cf6, #d946ef);
+
+  --sp-1: 4px;
+  --sp-2: 8px;
+  --sp-3: 12px;
+  --sp-4: 16px;
+  --sp-5: 20px;
+  --sp-6: 24px;
+  --sp-8: 32px;
+  --sp-10: 40px;
+  --sp-12: 48px;
+  --sp-16: 64px;
+
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+  --radius-xl: 20px;
+  --radius-full: 9999px;
+
+  --font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-mono: 'JetBrains Mono', 'SF Mono', monospace;
+
+  --text-xs: 11px;
+  --text-sm: 13px;
+  --text-base: 15px;
+  --text-lg: 17px;
+  --text-xl: 20px;
+  --text-2xl: 24px;
+  --text-3xl: 32px;
+
+  --transition-fast: 0.15s ease;
+  --transition-base: 0.2s ease;
+  --transition-slow: 0.3s ease;
+}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -1,0 +1,41 @@
+export interface PostResponse {
+  id: string
+  title: string
+  body: string
+  bodyHtml: string
+  authorId: string
+  authorUsername: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface PostListResponse {
+  posts: PostResponse[]
+}
+
+export interface CreatePostRequest {
+  title: string
+  body: string
+}
+
+export interface WhoamiResponse {
+  id: number
+  externalId: string
+  email: string
+  displayName: string
+  avatarUrl: string | null
+}
+
+export interface DevUser {
+  username: string
+  displayName: string
+}
+
+export interface DevUsersResponse {
+  users: DevUser[]
+}
+
+export interface LoginResponse {
+  sessionToken: string
+  user: DevUser
+}

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -1,0 +1,14 @@
+export function formatTimeAgo(isoString: string): string {
+  const date = new Date(isoString)
+  const now = new Date()
+  const seconds = Math.floor((now.getTime() - date.getTime()) / 1000)
+
+  if (seconds < 60) return 'just now'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days}d ago`
+  return date.toLocaleDateString()
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -6,6 +6,18 @@ export default defineConfig({
   base: '/app/',
   build: {
     outDir: '../build/web',
-    emptyOutDir: true
-  }
+    emptyOutDir: true,
+  },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+      '/logout': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
**Branch:** `cameronhotchkies/infra-theme`
**Base:** `MP3-posts-api-v3`
**Stack:** depends on #31

## Summary
React Router, Vite dev proxy, dark/light theme system with CSS custom properties, shared TypeScript API types, BBS logo in glassmorphism nav bar, and `formatTimeAgo` utility.

### Key files to review first
<details><summary>expand</summary>

- `web/src/styles/theme.css` — all CSS custom properties for Midnight Forge (dark) and Daylight Forge (light)
- `web/src/hooks/useTheme.tsx` — ThemeProvider with OS auto-detect + manual toggle, persisted in localStorage
- `web/src/types/api.ts` — TypeScript interfaces matching Wire proto JSON serialization (camelCase, string IDs)
- `web/src/App.tsx` — Router setup, glassmorphism nav with logo and theme toggle
- `web/vite.config.ts` — dev proxy for `/api` and `/logout` to backend on 8080

</details>

## Feel it.

```bash
just run
# Visit http://localhost:8080/app/
# Toggle theme with sun/moon button — persists on refresh
# Logo shows pixelated BBS icon in gradient container
cd web && npm run build  # TypeScript + Vite build passes
```

## Caveats / Follow-ups
- `formatTimeAgo()` has no i18n support
- No favicon generated from logo.svg yet

---

ref: #14
ref: #15