### PR TITLE
feat(ui): add auth context and dev login page

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,11 +1,14 @@
 import { BrowserRouter, Routes, Route, Link } from 'react-router-dom'
 import { ThemeProvider, useTheme } from './hooks/useTheme'
+import { AuthProvider, useAuth } from './hooks/useAuth'
+import LoginPage from './pages/LoginPage'
 import logo from './assets/logo.svg'
 import './styles/theme.css'
 import './App.css'
 
 function NavBar() {
   const { theme, toggleTheme } = useTheme()
+  const { user, isLoggedIn, isLoading, logout } = useAuth()
 
   return (
     <nav className="nav">
@@ -21,6 +24,16 @@ function NavBar() {
         >
           {theme === 'dark' ? '☀️' : '🌙'}
         </button>
+        {!isLoading && (
+          isLoggedIn ? (
+            <>
+              <span className="nav-user">{user?.displayName}</span>
+              <button onClick={logout} className="nav-btn">Logout</button>
+            </>
+          ) : (
+            <Link to="/login" className="nav-link">Login</Link>
+          )
+        )}
       </div>
     </nav>
   )
@@ -30,14 +43,17 @@ function App() {
   return (
     <BrowserRouter basename="/app">
       <ThemeProvider>
-        <div className="app">
-          <NavBar />
-          <main className="main">
-            <Routes>
-              <Route path="/" element={<div className="placeholder"><h1>Builder Syndicate</h1><p>A link aggregator for builders.</p></div>} />
-            </Routes>
-          </main>
-        </div>
+        <AuthProvider>
+          <div className="app">
+            <NavBar />
+            <main className="main">
+              <Routes>
+                <Route path="/" element={<div className="placeholder"><h1>Builder Syndicate</h1><p>A link aggregator for builders.</p></div>} />
+                <Route path="/login" element={<LoginPage />} />
+              </Routes>
+            </main>
+          </div>
+        </AuthProvider>
       </ThemeProvider>
     </BrowserRouter>
   )

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -1,0 +1,28 @@
+import { WhoamiResponse, DevUsersResponse, LoginResponse } from '../types/api'
+
+export async function fetchWhoami(): Promise<WhoamiResponse | null> {
+  const res = await fetch('/api/v1/whoami')
+  if (res.status === 401) return null
+  if (!res.ok) throw new Error('Failed to check auth status')
+  return res.json()
+}
+
+export async function fetchDevUsers(): Promise<DevUsersResponse> {
+  const res = await fetch('/api/v1/auth/dev-users')
+  if (!res.ok) throw new Error('Failed to fetch dev users')
+  return res.json()
+}
+
+export async function login(username: string): Promise<LoginResponse> {
+  const res = await fetch('/api/v1/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username }),
+  })
+  if (!res.ok) throw new Error('Login failed')
+  return res.json()
+}
+
+export async function logout(): Promise<void> {
+  await fetch('/logout', { method: 'POST', redirect: 'manual' })
+}

--- a/web/src/hooks/useAuth.tsx
+++ b/web/src/hooks/useAuth.tsx
@@ -1,0 +1,48 @@
+import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react'
+import { WhoamiResponse } from '../types/api'
+import { fetchWhoami, login as apiLogin, logout as apiLogout } from '../api/auth'
+
+interface AuthContextValue {
+  user: WhoamiResponse | null
+  isLoggedIn: boolean
+  isLoading: boolean
+  login: (username: string) => Promise<void>
+  logout: () => Promise<void>
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null)
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<WhoamiResponse | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    fetchWhoami()
+      .then(setUser)
+      .catch(() => setUser(null))
+      .finally(() => setIsLoading(false))
+  }, [])
+
+  const login = useCallback(async (username: string) => {
+    await apiLogin(username)
+    const whoami = await fetchWhoami()
+    setUser(whoami)
+  }, [])
+
+  const logout = useCallback(async () => {
+    await apiLogout()
+    setUser(null)
+  }, [])
+
+  return (
+    <AuthContext.Provider value={{ user, isLoggedIn: user !== null, isLoading, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider')
+  return ctx
+}

--- a/web/src/pages/LoginPage.css
+++ b/web/src/pages/LoginPage.css
@@ -1,0 +1,140 @@
+.login-page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: calc(100vh - 200px);
+}
+
+.login-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xl);
+  padding: var(--sp-10);
+  max-width: 440px;
+  width: 100%;
+  text-align: center;
+  box-shadow: var(--shadow-lg);
+}
+
+.login-logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 72px;
+  height: 72px;
+  background: var(--gradient-primary);
+  border-radius: var(--radius-lg);
+  margin-bottom: var(--sp-5);
+  box-shadow:
+    0 0 40px rgba(139, 92, 246, 0.4),
+    0 10px 30px rgba(0, 0, 0, 0.3);
+  animation: logoGlow 3s ease-in-out infinite alternate;
+}
+
+@keyframes logoGlow {
+  0% { box-shadow: 0 0 40px rgba(139, 92, 246, 0.4), 0 10px 30px rgba(0, 0, 0, 0.3); }
+  100% { box-shadow: 0 0 60px rgba(139, 92, 246, 0.6), 0 10px 40px rgba(0, 0, 0, 0.4); }
+}
+
+.login-title {
+  font-size: var(--text-3xl);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  background: var(--gradient-primary);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: var(--sp-2);
+}
+
+.login-subtitle {
+  color: var(--text-secondary);
+  font-size: var(--text-base);
+  margin-bottom: var(--sp-6);
+}
+
+.login-divider {
+  height: 1px;
+  background: var(--border-subtle);
+  margin-bottom: var(--sp-6);
+}
+
+.login-heading {
+  font-size: var(--text-xl);
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: var(--sp-2);
+}
+
+.login-hint {
+  color: var(--text-tertiary);
+  font-size: var(--text-sm);
+  margin-bottom: var(--sp-5);
+}
+
+.login-error {
+  background: var(--error-bg);
+  color: var(--error);
+  padding: var(--sp-3) var(--sp-4);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  margin-bottom: var(--sp-4);
+}
+
+.login-users {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+}
+
+.login-user-btn {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--sp-3) var(--sp-5);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast), transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.login-user-btn:hover {
+  background: var(--gradient-primary);
+  border-color: transparent;
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-glow);
+}
+
+.login-user-name {
+  font-size: var(--text-base);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.login-user-btn:hover .login-user-name {
+  color: white;
+}
+
+.login-user-id {
+  font-size: var(--text-sm);
+  color: var(--text-tertiary);
+}
+
+.login-user-btn:hover .login-user-id {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-loading {
+  text-align: center;
+  color: var(--text-tertiary);
+  padding: var(--sp-16) 0;
+}
+
+@media (max-width: 768px) {
+  .login-card {
+    padding: var(--sp-6);
+    margin: 0 var(--sp-4);
+  }
+}

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -1,0 +1,66 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../hooks/useAuth'
+import { fetchDevUsers } from '../api/auth'
+import { DevUser } from '../types/api'
+import logo from '../assets/logo.svg'
+import './LoginPage.css'
+
+function LoginPage() {
+  const { isLoggedIn, login } = useAuth()
+  const navigate = useNavigate()
+  const [devUsers, setDevUsers] = useState<DevUser[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (isLoggedIn) {
+      navigate('/', { replace: true })
+      return
+    }
+    fetchDevUsers()
+      .then((data) => setDevUsers(data.users))
+      .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load'))
+      .finally(() => setIsLoading(false))
+  }, [isLoggedIn, navigate])
+
+  const handleLogin = async (username: string) => {
+    try {
+      setError(null)
+      await login(username)
+      navigate('/', { replace: true })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Login failed')
+    }
+  }
+
+  if (isLoading) return <div className="login-loading">Loading...</div>
+
+  return (
+    <div className="login-page">
+      <div className="login-card">
+        <div className="login-logo"><img src={logo} alt="BBS" width={48} height={48} /></div>
+        <h1 className="login-title">Builder Syndicate</h1>
+        <p className="login-subtitle">Knowledge sharing for engineering teams</p>
+        <div className="login-divider" />
+        <h2 className="login-heading">Dev Login</h2>
+        <p className="login-hint">Select a user to sign in:</p>
+        {error && <div className="login-error">{error}</div>}
+        <div className="login-users">
+          {devUsers.map((u) => (
+            <button
+              key={u.username}
+              className="login-user-btn"
+              onClick={() => handleLogin(u.username)}
+            >
+              <span className="login-user-name">{u.displayName}</span>
+              <span className="login-user-id">{u.username}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default LoginPage


### PR DESCRIPTION
**Branch:** `cameronhotchkies/auth-login`
**Base:** `cameronhotchkies/infra-theme`
**Stack:** depends on #36

## Summary
Auth context with session check via `/api/v1/whoami`, dev login page with user selection buttons, and nav bar auth state (username + logout when logged in, login link when not). Login page includes BBS logo hero with animated glow.

### Key files to review first
<details><summary>expand</summary>

- `web/src/hooks/useAuth.tsx` — AuthProvider checks session on mount, exposes `{ user, isLoggedIn, login, logout }`
- `web/src/pages/LoginPage.tsx` — fetches dev users, gradient hover buttons, logo hero with glow animation
- `web/src/api/auth.ts` — fetch wrappers for whoami, dev-users, login, logout

</details>

## Feel it.

```bash
just run
# Visit http://localhost:8080/app/login
# Logo pulses with purple glow
# Click any user — nav updates to show name + logout
# Refresh — session persists (HttpOnly cookie)
# Click Logout — returns to login link in nav
```

## Caveats / Follow-ups
- Dev-only login flow — production auth TBD
- No loading spinner on login button click

---

ref: #14
ref: #15