### PR TITLE
feat(ui): add post feed page with card layout

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -120,24 +120,6 @@
   width: 100%;
 }
 
-.placeholder {
-  text-align: center;
-  padding: var(--sp-16) 0;
-}
-
-.placeholder h1 {
-  font-size: var(--text-3xl);
-  font-weight: 800;
-  letter-spacing: -0.03em;
-  color: var(--text-primary);
-  margin-bottom: var(--sp-2);
-}
-
-.placeholder p {
-  color: var(--text-secondary);
-  font-size: var(--text-lg);
-}
-
 /* Responsive */
 @media (max-width: 768px) {
   .nav {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Link } from 'react-router-dom'
 import { ThemeProvider, useTheme } from './hooks/useTheme'
 import { AuthProvider, useAuth } from './hooks/useAuth'
+import FeedPage from './pages/FeedPage'
 import LoginPage from './pages/LoginPage'
 import logo from './assets/logo.svg'
 import './styles/theme.css'
@@ -48,7 +49,7 @@ function App() {
             <NavBar />
             <main className="main">
               <Routes>
-                <Route path="/" element={<div className="placeholder"><h1>Builder Syndicate</h1><p>A link aggregator for builders.</p></div>} />
+                <Route path="/" element={<FeedPage />} />
                 <Route path="/login" element={<LoginPage />} />
               </Routes>
             </main>

--- a/web/src/api/posts.ts
+++ b/web/src/api/posts.ts
@@ -1,0 +1,14 @@
+import { PostListResponse, PostResponse } from '../types/api'
+
+export async function fetchPosts(): Promise<PostListResponse> {
+  const res = await fetch('/api/v1/posts')
+  if (!res.ok) throw new Error('Failed to fetch posts')
+  const data = await res.json()
+  return { posts: data.posts ?? [] }
+}
+
+export async function fetchPost(id: string): Promise<PostResponse> {
+  const res = await fetch(`/api/v1/posts/${id}`)
+  if (!res.ok) throw new Error('Failed to fetch post')
+  return res.json()
+}

--- a/web/src/pages/FeedPage.css
+++ b/web/src/pages/FeedPage.css
@@ -1,0 +1,98 @@
+.feed {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-6);
+}
+
+.feed-title {
+  font-size: var(--text-2xl);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  color: var(--text-primary);
+}
+
+.feed-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-4);
+}
+
+.post-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--sp-5);
+  transition: transform var(--transition-base), border-color var(--transition-base), box-shadow var(--transition-base);
+}
+
+.post-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--border-accent);
+  box-shadow: var(--shadow-md);
+}
+
+.post-card-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+}
+
+.post-card-title {
+  font-size: var(--text-lg);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.3;
+}
+
+.post-card-title a {
+  color: var(--text-primary);
+  transition: color var(--transition-fast);
+}
+
+.post-card-title a:hover {
+  color: var(--primary-light);
+}
+
+.post-card-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  font-size: var(--text-sm);
+}
+
+.post-card-author {
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.post-card-sep {
+  color: var(--text-muted);
+}
+
+.post-card-time {
+  color: var(--text-tertiary);
+}
+
+.feed-status {
+  text-align: center;
+  color: var(--text-tertiary);
+  padding: var(--sp-16) 0;
+  font-size: var(--text-base);
+}
+
+.feed-error {
+  color: var(--error);
+}
+
+.feed-empty {
+  text-align: center;
+  color: var(--text-tertiary);
+  padding: var(--sp-12) 0;
+  font-size: var(--text-base);
+}
+
+@media (max-width: 768px) {
+  .post-card {
+    padding: var(--sp-4);
+  }
+}

--- a/web/src/pages/FeedPage.tsx
+++ b/web/src/pages/FeedPage.tsx
@@ -1,0 +1,63 @@
+import { useState, useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { fetchPosts } from '../api/posts'
+import { PostResponse } from '../types/api'
+import { formatTimeAgo } from '../utils/format'
+import './FeedPage.css'
+
+function PostCard({ post }: { post: PostResponse }) {
+  return (
+    <article className="post-card">
+      <div className="post-card-content">
+        <h2 className="post-card-title">
+          <Link to={`/posts/${post.id}`}>{post.title}</Link>
+        </h2>
+        <div className="post-card-meta">
+          <span className="post-card-author">{post.authorUsername}</span>
+          <span className="post-card-sep">&middot;</span>
+          <time className="post-card-time">{formatTimeAgo(post.createdAt)}</time>
+        </div>
+      </div>
+    </article>
+  )
+}
+
+function FeedPage() {
+  const [posts, setPosts] = useState<PostResponse[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetchPosts()
+      .then((data) => setPosts(data.posts))
+      .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load'))
+      .finally(() => setIsLoading(false))
+  }, [])
+
+  if (isLoading) return <div className="feed-status">Loading posts...</div>
+  if (error) return <div className="feed-status feed-error">{error}</div>
+
+  if (posts.length === 0) {
+    return (
+      <div className="feed">
+        <h1 className="feed-title">Feed</h1>
+        <div className="feed-empty">
+          <p>No posts yet. Be the first to share something.</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="feed">
+      <h1 className="feed-title">Feed</h1>
+      <div className="feed-list">
+        {posts.map((post) => (
+          <PostCard key={post.id} post={post} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default FeedPage


### PR DESCRIPTION
## Summary

Feed page with post cards — fetches `GET /api/v1/posts`, displays title, author, and relative timestamp with hover lift animation. Handles Wire proto empty repeated fields.

### Key files to review first

<details>
<summary>expand</summary>

- `web/src/pages/FeedPage.tsx` — PostCard component, loading/empty/error states
- `web/src/api/posts.ts` — fetch wrappers with `data.posts ?? []` guard for Wire proto empty arrays

</details>

## Feel it.

```bash
just run

# Create a post first
curl -s -X POST http://localhost:8080/api/v1/auth/login \
  -H "Content-Type: application/json" \
  -d '{"username":"dev-alice"}' -c cookies.txt

curl -s -X POST http://localhost:8080/api/v1/posts \
  -H "Content-Type: application/json" \
  -b cookies.txt \
  -d '{"title":"Hello","body":"# World"}'

# Visit http://localhost:8080/app/
# Card shows title, author "Alice", relative timestamp
# Hover card — lift effect with purple border glow
# Click title — navigates to detail page
```

## Caveats / Follow-ups

- No pagination
- Posts sorted by API default (newest first)
- Auth gating on feed #41

---

ref: #14