### PR TITLE
feat(ui): add post detail page with rendered HTML body

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,7 @@ import { ThemeProvider, useTheme } from './hooks/useTheme'
 import { AuthProvider, useAuth } from './hooks/useAuth'
 import FeedPage from './pages/FeedPage'
 import LoginPage from './pages/LoginPage'
+import PostDetailPage from './pages/PostDetailPage'
 import logo from './assets/logo.svg'
 import './styles/theme.css'
 import './App.css'
@@ -50,6 +51,7 @@ function App() {
             <main className="main">
               <Routes>
                 <Route path="/" element={<FeedPage />} />
+                <Route path="/posts/:id" element={<PostDetailPage />} />
                 <Route path="/login" element={<LoginPage />} />
               </Routes>
             </main>

--- a/web/src/pages/PostDetailPage.css
+++ b/web/src/pages/PostDetailPage.css
@@ -1,0 +1,188 @@
+.post-detail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-5);
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  transition: color var(--transition-fast);
+}
+
+.back-link:hover {
+  color: var(--primary-light);
+}
+
+.post-detail-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--sp-8);
+}
+
+.post-detail-title {
+  font-size: var(--text-2xl);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text-primary);
+  line-height: 1.3;
+  margin-bottom: var(--sp-3);
+}
+
+.post-detail-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  font-size: var(--text-sm);
+  margin-bottom: var(--sp-6);
+  padding-bottom: var(--sp-6);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.post-detail-author {
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.post-detail-sep {
+  color: var(--text-muted);
+}
+
+.post-detail-time {
+  color: var(--text-tertiary);
+}
+
+/* Prose styles for rendered markdown HTML */
+.post-detail-body {
+  color: var(--text-secondary);
+  font-size: var(--text-base);
+  line-height: 1.75;
+}
+
+.post-detail-body h1,
+.post-detail-body h2,
+.post-detail-body h3,
+.post-detail-body h4,
+.post-detail-body h5,
+.post-detail-body h6 {
+  color: var(--text-primary);
+  margin-top: var(--sp-6);
+  margin-bottom: var(--sp-3);
+  line-height: 1.3;
+}
+
+.post-detail-body h1 { font-size: var(--text-xl); font-weight: 700; }
+.post-detail-body h2 { font-size: var(--text-lg); font-weight: 700; }
+.post-detail-body h3 { font-size: var(--text-base); font-weight: 600; }
+
+.post-detail-body p {
+  margin-bottom: var(--sp-4);
+}
+
+.post-detail-body a {
+  color: var(--primary-light);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.post-detail-body a:hover {
+  color: var(--primary);
+}
+
+.post-detail-body ul,
+.post-detail-body ol {
+  margin-bottom: var(--sp-4);
+  padding-left: var(--sp-6);
+}
+
+.post-detail-body li {
+  margin-bottom: var(--sp-1);
+}
+
+.post-detail-body blockquote {
+  border-left: 3px solid var(--primary);
+  padding-left: var(--sp-4);
+  margin: var(--sp-4) 0;
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+
+.post-detail-body pre {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding: var(--sp-4);
+  margin: var(--sp-4) 0;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+}
+
+.post-detail-body code {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  background: var(--bg-elevated);
+  padding: 2px var(--sp-1);
+  border-radius: var(--radius-sm);
+}
+
+.post-detail-body pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+}
+
+.post-detail-body img {
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--radius-md);
+  margin: var(--sp-4) 0;
+}
+
+.post-detail-body table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: var(--sp-4) 0;
+}
+
+.post-detail-body th,
+.post-detail-body td {
+  border: 1px solid var(--border-subtle);
+  padding: var(--sp-2) var(--sp-3);
+  text-align: left;
+}
+
+.post-detail-body th {
+  background: var(--bg-elevated);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.post-detail-body hr {
+  border: none;
+  border-top: 1px solid var(--border-subtle);
+  margin: var(--sp-6) 0;
+}
+
+/* Status states */
+.detail-status {
+  text-align: center;
+  color: var(--text-tertiary);
+  padding: var(--sp-16) 0;
+}
+
+.detail-error {
+  color: var(--error);
+}
+
+@media (max-width: 768px) {
+  .post-detail-card {
+    padding: var(--sp-5);
+  }
+}

--- a/web/src/pages/PostDetailPage.tsx
+++ b/web/src/pages/PostDetailPage.tsx
@@ -1,0 +1,45 @@
+import { useState, useEffect } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import { fetchPost } from '../api/posts'
+import { PostResponse } from '../types/api'
+import { formatTimeAgo } from '../utils/format'
+import './PostDetailPage.css'
+
+function PostDetailPage() {
+  const { id } = useParams<{ id: string }>()
+  const [post, setPost] = useState<PostResponse | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!id) return
+    fetchPost(id)
+      .then(setPost)
+      .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load'))
+      .finally(() => setIsLoading(false))
+  }, [id])
+
+  if (isLoading) return <div className="detail-status">Loading...</div>
+  if (error) return <div className="detail-status detail-error">{error}</div>
+  if (!post) return <div className="detail-status">Post not found.</div>
+
+  return (
+    <div className="post-detail">
+      <Link to="/" className="back-link">&larr; Back to Feed</Link>
+      <article className="post-detail-card">
+        <h1 className="post-detail-title">{post.title}</h1>
+        <div className="post-detail-meta">
+          <span className="post-detail-author">{post.authorUsername}</span>
+          <span className="post-detail-sep">&middot;</span>
+          <time className="post-detail-time">{formatTimeAgo(post.createdAt)}</time>
+        </div>
+        <div
+          className="post-detail-body"
+          dangerouslySetInnerHTML={{ __html: post.bodyHtml }}
+        />
+      </article>
+    </div>
+  )
+}
+
+export default PostDetailPage


### PR DESCRIPTION
## Summary

Post detail page — fetches by ID, renders server-sanitized markdown HTML with prose styling for headings, code blocks, links, blockquotes, and lists.

### Key files to review first

<details>
<summary>expand</summary>

- `web/src/pages/PostDetailPage.tsx` — fetches post, renders `bodyHtml` via `dangerouslySetInnerHTML` (server-sanitized by OWASP)
- `web/src/pages/PostDetailPage.css` — prose styles for rendered markdown content

</details>

## Feel it.

```bash
just run

# Create a post with rich markdown
curl -s -X POST http://localhost:8080/api/v1/auth/login \
  -H "Content-Type: application/json" \
  -d '{"username":"dev-alice"}' -c cookies.txt

curl -s -X POST http://localhost:8080/api/v1/posts \
  -H "Content-Type: application/json" \
  -b cookies.txt \
  -d '{"title":"Markdown Test","body":"# Heading\n\n**bold** and `code`\n\n- list item\n\n> blockquote\n\n```js\nconsole.log(42)\n```"}'

# Visit http://localhost:8080/app/posts/{id}
# Heading, bold, code, list, blockquote, code block all render styled
# "Back to Feed" link returns to feed
# Non-existent ID shows "Post not found"
```

## Caveats / Follow-ups

- No edit/delete UI yet
- HTML is server-sanitized — XSS risk is minimal

---

Closes: #14