### PR TITLE
feat(ui): add post creation form with auth guard

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -111,6 +111,22 @@
   border-color: var(--border-accent);
 }
 
+.nav-new-post {
+  background: var(--gradient-primary);
+  color: white;
+  padding: var(--sp-1) var(--sp-3);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.nav-new-post:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-glow);
+  color: white;
+}
+
 /* Main content */
 .main {
   flex: 1;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@ import { AuthProvider, useAuth } from './hooks/useAuth'
 import FeedPage from './pages/FeedPage'
 import LoginPage from './pages/LoginPage'
 import PostDetailPage from './pages/PostDetailPage'
+import CreatePostPage from './pages/CreatePostPage'
 import logo from './assets/logo.svg'
 import './styles/theme.css'
 import './App.css'
@@ -29,6 +30,7 @@ function NavBar() {
         {!isLoading && (
           isLoggedIn ? (
             <>
+              <Link to="/posts/new" className="nav-new-post">+ New Post</Link>
               <span className="nav-user">{user?.displayName}</span>
               <button onClick={logout} className="nav-btn">Logout</button>
             </>
@@ -51,6 +53,7 @@ function App() {
             <main className="main">
               <Routes>
                 <Route path="/" element={<FeedPage />} />
+                <Route path="/posts/new" element={<CreatePostPage />} />
                 <Route path="/posts/:id" element={<PostDetailPage />} />
                 <Route path="/login" element={<LoginPage />} />
               </Routes>

--- a/web/src/api/posts.ts
+++ b/web/src/api/posts.ts
@@ -1,4 +1,4 @@
-import { PostListResponse, PostResponse } from '../types/api'
+import { PostListResponse, PostResponse, CreatePostRequest } from '../types/api'
 
 export async function fetchPosts(): Promise<PostListResponse> {
   const res = await fetch('/api/v1/posts')
@@ -10,5 +10,15 @@ export async function fetchPosts(): Promise<PostListResponse> {
 export async function fetchPost(id: string): Promise<PostResponse> {
   const res = await fetch(`/api/v1/posts/${id}`)
   if (!res.ok) throw new Error('Failed to fetch post')
+  return res.json()
+}
+
+export async function createPost(data: CreatePostRequest): Promise<PostResponse> {
+  const res = await fetch('/api/v1/posts', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+  if (!res.ok) throw new Error('Failed to create post')
   return res.json()
 }

--- a/web/src/pages/CreatePostPage.css
+++ b/web/src/pages/CreatePostPage.css
@@ -1,0 +1,139 @@
+.create-post {
+  max-width: 700px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.create-title {
+  font-size: var(--text-2xl);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  color: var(--text-primary);
+  margin-bottom: var(--sp-6);
+}
+
+.create-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-5);
+}
+
+.create-error {
+  background: var(--error-bg);
+  color: var(--error);
+  padding: var(--sp-3) var(--sp-4);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+}
+
+.form-label {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.form-input {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-family: var(--font-family);
+  font-size: var(--text-base);
+  padding: var(--sp-3) var(--sp-4);
+  outline: none;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.form-input:focus {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--primary-glow);
+}
+
+.form-input::placeholder {
+  color: var(--text-muted);
+}
+
+.form-textarea {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  padding: var(--sp-4);
+  outline: none;
+  resize: vertical;
+  min-height: 200px;
+  line-height: 1.6;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.form-textarea:focus {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--primary-glow);
+}
+
+.form-textarea::placeholder {
+  color: var(--text-muted);
+  font-family: var(--font-family);
+}
+
+.create-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--sp-3);
+  padding-top: var(--sp-2);
+}
+
+.btn {
+  font-family: var(--font-family);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: var(--sp-2) var(--sp-5);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast), background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.btn-primary {
+  background: var(--gradient-primary);
+  color: white;
+  border: none;
+}
+
+.btn-primary:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-glow);
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-subtle);
+}
+
+.btn-ghost:hover {
+  color: var(--text-primary);
+  border-color: var(--border-accent);
+  background: var(--bg-hover);
+}
+
+.create-status {
+  text-align: center;
+  color: var(--text-tertiary);
+  padding: var(--sp-16) 0;
+}

--- a/web/src/pages/CreatePostPage.tsx
+++ b/web/src/pages/CreatePostPage.tsx
@@ -1,0 +1,92 @@
+import { useState, useEffect, FormEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../hooks/useAuth'
+import { createPost } from '../api/posts'
+import './CreatePostPage.css'
+
+function CreatePostPage() {
+  const { isLoggedIn, isLoading } = useAuth()
+  const navigate = useNavigate()
+  const [title, setTitle] = useState('')
+  const [body, setBody] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!isLoading && !isLoggedIn) {
+      navigate('/login', { replace: true })
+    }
+  }, [isLoggedIn, isLoading, navigate])
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    if (!title.trim() || !body.trim()) {
+      setError('Title and body are required.')
+      return
+    }
+    setIsSubmitting(true)
+    setError(null)
+    try {
+      const post = await createPost({ title: title.trim(), body: body.trim() })
+      navigate(`/posts/${post.id}`, { replace: true })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create post')
+      setIsSubmitting(false)
+    }
+  }
+
+  if (isLoading) return <div className="create-status">Loading...</div>
+  if (!isLoggedIn) return null
+
+  return (
+    <div className="create-post">
+      <h1 className="create-title">New Post</h1>
+      <form className="create-form" onSubmit={handleSubmit}>
+        {error && <div className="create-error">{error}</div>}
+        <div className="form-group">
+          <label htmlFor="post-title" className="form-label">Title</label>
+          <input
+            id="post-title"
+            type="text"
+            className="form-input"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="What are you sharing?"
+            maxLength={300}
+            required
+          />
+        </div>
+        <div className="form-group">
+          <label htmlFor="post-body" className="form-label">Body (Markdown)</label>
+          <textarea
+            id="post-body"
+            className="form-textarea"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            placeholder="Write your post in Markdown..."
+            rows={12}
+            required
+          />
+        </div>
+        <div className="create-actions">
+          <button
+            type="button"
+            className="btn btn-ghost"
+            onClick={() => navigate('/')}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="btn btn-primary"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? 'Publishing...' : 'Publish Post'}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+export default CreatePostPage


### PR DESCRIPTION
## Summary

Post creation form with auth guard — logged-in users get a gradient "+ New Post" nav button, form has title + markdown body textarea, submits via API and redirects to the new post's detail page.

### Key files to review first

<details>
<summary>expand</summary>

- `web/src/pages/CreatePostPage.tsx` — auth guard redirect, controlled form, submit + navigate to detail
- `web/src/App.tsx` — conditional "+ New Post" gradient button in nav (only when authenticated)

</details>

## Feel it.

```bash
just run

# Visit http://localhost:8080/app/
# Log in as any user
# "+ New Post" button appears in nav
# Click it — fill in title and body (supports markdown)
# Submit — redirects to new post detail page
# Back to feed — new post appears at top

# Auth guard:
# Log out, visit http://localhost:8080/app/posts/new directly
# Redirects to login page
```

## Caveats / Follow-ups

- No markdown preview while editing
- No draft saving
- No input length validation

---

Closes: #15