### PR TITLE
feat(ui): require login for all routes (#41)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route, Link } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Link, Navigate, useLocation } from 'react-router-dom'
 import { ThemeProvider, useTheme } from './hooks/useTheme'
 import { AuthProvider, useAuth } from './hooks/useAuth'
 import FeedPage from './pages/FeedPage'
@@ -43,6 +43,15 @@ function NavBar() {
   )
 }
 
+function RequireAuth({ children }: { children: React.ReactNode }) {
+  const { isLoggedIn, isLoading } = useAuth()
+  const location = useLocation()
+
+  if (isLoading) return <div className="auth-loading">Loading...</div>
+  if (!isLoggedIn) return <Navigate to="/login" state={{ from: location.pathname }} replace />
+  return <>{children}</>
+}
+
 function App() {
   return (
     <BrowserRouter basename="/app">
@@ -52,10 +61,10 @@ function App() {
             <NavBar />
             <main className="main">
               <Routes>
-                <Route path="/" element={<FeedPage />} />
-                <Route path="/posts/new" element={<CreatePostPage />} />
-                <Route path="/posts/:id" element={<PostDetailPage />} />
                 <Route path="/login" element={<LoginPage />} />
+                <Route path="/" element={<RequireAuth><FeedPage /></RequireAuth>} />
+                <Route path="/posts/new" element={<RequireAuth><CreatePostPage /></RequireAuth>} />
+                <Route path="/posts/:id" element={<RequireAuth><PostDetailPage /></RequireAuth>} />
               </Routes>
             </main>
           </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -43,6 +43,14 @@ function NavBar() {
   )
 }
 
+function StripTrailingSlash() {
+  const location = useLocation()
+  if (location.pathname !== '/' && location.pathname.endsWith('/')) {
+    return <Navigate to={location.pathname.slice(0, -1)} replace />
+  }
+  return null
+}
+
 function RequireAuth({ children }: { children: React.ReactNode }) {
   const { isLoggedIn, isLoading } = useAuth()
   const location = useLocation()
@@ -60,6 +68,7 @@ function App() {
           <div className="app">
             <NavBar />
             <main className="main">
+              <StripTrailingSlash />
               <Routes>
                 <Route path="/login" element={<LoginPage />} />
                 <Route path="/" element={<RequireAuth><FeedPage /></RequireAuth>} />

--- a/web/src/pages/CreatePostPage.tsx
+++ b/web/src/pages/CreatePostPage.tsx
@@ -1,22 +1,14 @@
-import { useState, useEffect, FormEvent } from 'react'
+import { useState, FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useAuth } from '../hooks/useAuth'
 import { createPost } from '../api/posts'
 import './CreatePostPage.css'
 
 function CreatePostPage() {
-  const { isLoggedIn, isLoading } = useAuth()
   const navigate = useNavigate()
   const [title, setTitle] = useState('')
   const [body, setBody] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (!isLoading && !isLoggedIn) {
-      navigate('/login', { replace: true })
-    }
-  }, [isLoggedIn, isLoading, navigate])
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
@@ -34,9 +26,6 @@ function CreatePostPage() {
       setIsSubmitting(false)
     }
   }
-
-  if (isLoading) return <div className="create-status">Loading...</div>
-  if (!isLoggedIn) return null
 
   return (
     <div className="create-post">

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 import { fetchDevUsers } from '../api/auth'
 import { DevUser } from '../types/api'
@@ -9,13 +9,15 @@ import './LoginPage.css'
 function LoginPage() {
   const { isLoggedIn, login } = useAuth()
   const navigate = useNavigate()
+  const location = useLocation()
+  const from = (location.state as { from?: string })?.from ?? '/'
   const [devUsers, setDevUsers] = useState<DevUser[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     if (isLoggedIn) {
-      navigate('/', { replace: true })
+      navigate(from, { replace: true })
       return
     }
     fetchDevUsers()
@@ -28,7 +30,7 @@ function LoginPage() {
     try {
       setError(null)
       await login(username)
-      navigate('/', { replace: true })
+      navigate(from, { replace: true })
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Login failed')
     }


### PR DESCRIPTION
## Summary

Global auth guard requiring login for all routes per PRD F-01. Unauthenticated users are redirected to `/login` with return-to-origin after successful login. Removes duplicate auth guard from CreatePostPage.

### Key files to review first

<details>
<summary>expand</summary>

- `web/src/App.tsx` — `RequireAuth` wrapper component, all routes except `/login` wrapped
- `web/src/pages/LoginPage.tsx` — reads `location.state.from` to redirect back after login
- `web/src/pages/CreatePostPage.tsx` — removed duplicate inline auth guard (now handled globally)

</details>

## Feel it.

```bash
just run

# Unauthenticated: visit http://localhost:8080/app/
# → redirected to /login

# Try direct deep link: http://localhost:8080/app/posts/94
# → redirected to /login

# Log in → returned to the page you originally requested
# Log out → redirected to /login
```

## Caveats / Follow-ups

- This is a frontend-only guard — backend API auth (ticket #29 AccessInterceptor) is separate
- SPA serves HTML to unauthenticated users; redirect happens client-side

---

Closes: #41
ref: #29